### PR TITLE
change run loop mode to common to accommodate for scroll views

### DIFF
--- a/Sources/Looping/Rendering/DisplayLink.swift
+++ b/Sources/Looping/Rendering/DisplayLink.swift
@@ -25,7 +25,7 @@ final class DisplayLink {
 
     private lazy var displayLink: CADisplayLink = {
         let displayLink = CADisplayLink(target: WeakTargetProxy(target: self), selector: #selector(WeakTargetProxy.proxy))
-        displayLink.add(to: .main, forMode: .default)
+        displayLink.add(to: .main, forMode: .common)
         displayLink.isPaused = true
         displayLink.preferredFramesPerSecond = preferredFramesPerSecond
         isInitiated = true


### PR DESCRIPTION
Because the app is not in `RunLoop.Mode.default` while scrolling a `UIScrollView`, but in `RunLoop.Mode.tracking` instead, the animation is not updating while scrolling and looks paused. Changing the `RunLoop.Mode` to `.common`, which covers both modes, fixes the issue.