### PR TITLE
fix build on Xcode > 12.3

### DIFF
--- a/Sources/LoopingWebP/WebPCodec.swift
+++ b/Sources/LoopingWebP/WebPCodec.swift
@@ -233,6 +233,17 @@ private extension WebPCodec {
                     defer { WebPDemuxReleaseChunkIterator(&chunkIterator) }
 
                     // Copy the ICC data (really cheap, less than 10KB)
+                    #if compiler(>=5.3.2)
+                    if let profileData = CFDataCreate(kCFAllocatorDefault, chunkIterator.chunk.bytes, chunkIterator.chunk.size),
+                       let iccColorspace = CGColorSpace(iccData: profileData) {
+
+
+                        // Filter out non RGB color models
+                        if iccColorspace.model == .rgb {
+                            colorspace = iccColorspace
+                        }
+                    }
+                    #else
                     if let profileData = CFDataCreate(kCFAllocatorDefault, chunkIterator.chunk.bytes, chunkIterator.chunk.size) {
                         let iccColorspace = CGColorSpace(iccData: profileData)
 
@@ -241,6 +252,7 @@ private extension WebPCodec {
                             colorspace = iccColorspace
                         }
                     }
+                    #endif
                 }
             }
         }


### PR DESCRIPTION
Xcode 12.4 and the iOS 14.4 introduced a breaking api change, CGColorSpace init(iccData:) is now a failable initializer
Since SDK versions, Xcode and swift versions are tightly linked together, it safe to rely on swift version to do the switch

Tested builds on Xcode 12.0, 12.1, 12.2, 12.3 and 12.4