### PR TITLE
fix: remove NSCache Cost Limit (issue with big assets)

### DIFF
--- a/Sources/Looping/Models/FrameCache.swift
+++ b/Sources/Looping/Models/FrameCache.swift
@@ -2,20 +2,12 @@ import Foundation
 
 import class ImageIO.CGImage
 
-private extension CGImage {
-
-    var cost: Int {
-        return height * width
-    }
-}
-
 final class FrameCache {
     let cacheObject = NSCache<NSString, CGImage>()
 
     init(image: LoopImage) {
         cacheObject.name = "looping.frameCache.\(image.uuid)"
         cacheObject.countLimit = image.frameCount
-        cacheObject.totalCostLimit = 100 * 1024 * 1024 // 100 MB
     }
 
     deinit {
@@ -23,7 +15,7 @@ final class FrameCache {
     }
 
     func set(frame: CGImage, forKey key: String) {
-        cacheObject.setObject(frame, forKey: key as NSString, cost: frame.cost)
+        cacheObject.setObject(frame, forKey: key as NSString)
     }
 
     func removeImage(forKey key: String) {


### PR DESCRIPTION
Remove cost limit for the cache, cache cleaning is handled by memory warnings as well